### PR TITLE
Add a link to the event signup form

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
         <h2 class="center">Berlin <span class="mozilla--title">moz://a</span> Community Space</h2>
         <p class="center">GSG-Hof Schlesische Straße Gebäude 3, 4th floor<br> Schlesische Straße 27<br> 10997 Berlin</p>
       </div>
+      <h2 class="mozilla--title">Events</h2>
+      <p>We regularly host tech meetups, learning groups and other web-related gatherings, free of charge. Our space is sponsored and maintained by Mozilla, but we operate based on a trust model that enables volunteers to indepently host their own events.</p>
+      <p><strong>Do you want to run an event in the Mozilla Community Space? Please get in touch <a href="https://goo.gl/forms/4fZZzBB9QnCUemyd2">here</a>!</strong></p>
       <h2 class="mozilla--title">Calendar</h2>
       <iframe class="block mx-auto community--calendar" src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showCalendars=0&amp;showPrint=0&amp;height=600&amp;wkst=2&amp;bgcolor=%23ffffff&amp;src=pdbuh2radv9coblu6o4rmob8kk%40group.calendar.google.com&amp;color=%2323164E&amp;ctz=Europe%2FBerlin" style="border-width:0" height="600" frameborder="0" scrolling="no"></iframe>
     </main>


### PR DESCRIPTION
This adds a link to a Google Form that posts emails to the community-berlin-peers list. We prepared that form and the mailing list at the Open Mozilla Night tonight. It's currently a bit simple, I'll work on improving the automated email messages later. It should be enough to get us rolling.

Can you all take a quick look and sign this off, please? Feel free to nitpick on the wording in this PR.